### PR TITLE
feat: respect custom etag

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ use std::pin::Pin;
 use actix_service::{forward_ready, Service, Transform};
 use actix_web::body::{BodySize, BoxBody, EitherBody, MessageBody, None as BodyNone};
 use actix_web::dev::{ServiceRequest, ServiceResponse};
-use actix_web::http::header::{ETag, EntityTag, IfNoneMatch, TryIntoHeaderPair};
+use actix_web::http::header::{ETag, EntityTag, IfNoneMatch, TryIntoHeaderPair, Header};
 use actix_web::http::Method;
 use actix_web::web::Bytes;
 use actix_web::{HttpMessage, HttpResponse};
@@ -55,10 +55,10 @@ use xxhash_rust::xxh3::xxh3_128;
 pub struct Etag;
 
 impl<S, B> Transform<S, ServiceRequest> for Etag
-where
-    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = actix_web::Error>,
-    S::Future: 'static,
-    B: MessageBody + 'static,
+    where
+        S: Service<ServiceRequest, Response=ServiceResponse<B>, Error=actix_web::Error>,
+        S::Future: 'static,
+        B: MessageBody + 'static,
 {
     type Response = ServiceResponse<EitherBody<BoxBody>>;
     type Error = actix_web::Error;
@@ -70,7 +70,9 @@ where
         ok(EtagMiddleware { service })
     }
 }
+
 type Buffer = str_buf::StrBuf<62>;
+
 ///
 /// The service holder for the transform that should happen
 pub struct EtagMiddleware<S> {
@@ -78,16 +80,16 @@ pub struct EtagMiddleware<S> {
 }
 
 impl<S, B> Service<ServiceRequest> for EtagMiddleware<S>
-where
-    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = actix_web::Error>,
-    S::Future: 'static,
-    B: MessageBody + 'static,
+    where
+        S: Service<ServiceRequest, Response=ServiceResponse<B>, Error=actix_web::Error>,
+        S::Future: 'static,
+        B: MessageBody + 'static,
 {
     type Response = ServiceResponse<EitherBody<BoxBody>>;
     type Error = actix_web::Error;
     #[allow(clippy::type_complexity)]
     type Future =
-        Pin<Box<dyn Future<Output = Result<ServiceResponse<EitherBody<BoxBody>>, Self::Error>>>>;
+    Pin<Box<dyn Future<Output=Result<ServiceResponse<EitherBody<BoxBody>>, Self::Error>>>>;
     forward_ready!(service);
 
     fn call(&self, req: ServiceRequest) -> Self::Future {
@@ -97,6 +99,7 @@ where
 
         Box::pin(async move {
             let res: ServiceResponse<B> = fut.await?;
+
             match method {
                 Method::GET => {
                     let mut modified = true;
@@ -110,12 +113,18 @@ where
                         _ => body.boxed(),
                     });
                     if let Some(bytes) = payload {
-                        let response_hash = xxh3_128(&bytes);
-                        let base64 =
-                            base64::prelude::BASE64_URL_SAFE.encode(response_hash.to_le_bytes());
-                        let mut buff = Buffer::new();
-                        let _ = write!(buff, "{:x}-{}", bytes.len(), base64);
-                        let tag = EntityTag::new_weak(buff.to_string());
+                        let custom_etag = res.response().headers().get(ETag::name());
+                        let tag = match custom_etag.and_then(|etag| etag.to_str().ok()) {
+                            Some(custom_etag) => EntityTag::new_weak(custom_etag.to_owned()),
+                            None => {
+                                let response_hash = xxh3_128(&bytes);
+                                let base64 = base64::prelude::BASE64_URL_SAFE.encode(response_hash.to_le_bytes());
+                                let mut buff = Buffer::new();
+                                let _ = write!(buff, "{:x}-{}", bytes.len(), base64);
+                                EntityTag::new_weak(buff.to_string())
+                            }
+                        };
+
                         if let Some(request_etag_header) = request_etag_header {
                             if request_etag_header == IfNoneMatch::Any
                                 || request_etag_header.to_string() == tag.to_string()
@@ -288,7 +297,7 @@ mod tests {
                 .wrap(actix_web::middleware::Compress::default())
                 .route("/", web::get().to(image)),
         )
-        .await;
+            .await;
         let match_header = IfNoneMatch::Items(vec![EntityTag::new_weak(
             "3aee-m0RKLkLoLS6kJ1N8xt0D5A==".to_string(),
         )]);
@@ -296,6 +305,28 @@ mod tests {
             .append_header(match_header)
             .append_header(("Accept-Encoding", "gzip"))
             .to_request();
+        let res = call_service(&mut app, req).await;
+
+        assert_eq!(res.status(), StatusCode::NOT_MODIFIED);
+        assert_eq!(res.into_body().size(), BodySize::None);
+    }
+
+    #[actix_web::test]
+    async fn test_explicit_etag_matches_if_none_match() {
+        let mut app = init_service(
+            App::new()
+                .wrap(Etag)
+                .route("/", web::get().to(|| async {
+                    HttpResponse::Ok()
+                        .insert_header((ETag::name(), "custometag"))
+                        .body("Response with a custom ETag")
+                }))
+        ).await;
+        let match_header = IfNoneMatch::Items(vec![EntityTag::new_weak(
+            "custometag".to_string(),
+        )]);
+
+        let req = TestRequest::default().append_header(match_header).to_request();
         let res = call_service(&mut app, req).await;
 
         assert_eq!(res.status(), StatusCode::NOT_MODIFIED);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,9 +70,7 @@ where
         ok(EtagMiddleware { service })
     }
 }
-
 type Buffer = str_buf::StrBuf<62>;
-
 ///
 /// The service holder for the transform that should happen
 pub struct EtagMiddleware<S> {
@@ -96,7 +94,6 @@ where
         let request_etag_header: Option<IfNoneMatch> = req.get_header();
         let method = req.method().clone();
         let fut = self.service.call(req);
-
         Box::pin(async move {
             let res: ServiceResponse<B> = fut.await?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,6 @@ where
         let fut = self.service.call(req);
         Box::pin(async move {
             let res: ServiceResponse<B> = fut.await?;
-
             match method {
                 Method::GET => {
                     let mut modified = true;


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

Allow custom etag headers that will be later matched with if-none-match to take precedence over the calculated etags. Previously we had no way to opt out of the default mechanism.

Implementation wise I tried to make this change as least intrusive as possible and hopefully found the  right seam in the code. 

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
